### PR TITLE
[BN-1571]: Update docker image names and publish locations

### DIFF
--- a/.github/workflows/_docker_publish_dev.yml
+++ b/.github/workflows/_docker_publish_dev.yml
@@ -33,4 +33,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push images to registries
-        run: DOCKER_PUBLISH_DEV_TAG=true sbt node/Docker/publish strata-indexer/Docker/publish
+        run: DOCKER_PUBLISH_DEV_TAG=true sbt node/Docker/publish genus/Docker/publish

--- a/.github/workflows/_docker_publish_dev.yml
+++ b/.github/workflows/_docker_publish_dev.yml
@@ -2,17 +2,6 @@ name: Publish Docker Images (Dev)
 
 on:
   workflow_call:
-    inputs:
-      remote-repository:
-        description: "Name of the GCP managed Artifact Registry."
-        default: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev/"
-        required: false
-        type: string
-      registry-auth-location:
-        description: "Name of the GCP managed Artifact Registry."
-        default: "us-central1-docker.pkg.dev"
-        required: false
-        type: string
 
 jobs:
   publish_docker_images:
@@ -29,7 +18,7 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      # First publish bifrost-node to Dockerhub and GHCR (dev image).
+      # First publish strata-node to Dockerhub and GHCR (dev image).
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -44,28 +33,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push images to registries
-        run: DOCKER_PUBLISH_DEV_TAG=true sbt node/Docker/publish genus/Docker/publish
-
-      # Then publish other iamges to GCP Artifact Registry
-      - id: "auth"
-        name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
-        with:
-          workload_identity_provider: ${{ secrets.GCP_OIDC_PROVIDER_NAME }}
-          service_account: ${{ secrets.GCP_OIDC_SERVICE_ACCOUNT_EMAIL }}
-
-      - name: Set up gcloud
-        uses: "google-github-actions/setup-gcloud@v0"
-
-      - name: Auth Artifact Registry
-        run: gcloud auth configure-docker ${{ inputs.registry-auth-location }}
-
-      - name: Stage Docker Image
-        run: sbt Docker/publishLocal
-
-      - name: Tag and push image to remote registry
-        run: |
-          docker tag $(docker images toplprotocol/testnet-simulation-orchestrator --format "{{.ID}}" | head -n 1) ${{ inputs.remote-repository }}/testnet-simulation-orchestrator:$(docker images toplprotocol/testnet-simulation-orchestrator --format "{{.Tag}}" | head -n 1)
-          docker tag $(docker images toplprotocol/network-delayer --format "{{.ID}}" | head -n 1) ${{ inputs.remote-repository }}/network-delayer:$(docker images toplprotocol/network-delayer --format "{{.Tag}}" | head -n 1)
-          docker push --all-tags ${{ inputs.remote-repository }}/testnet-simulation-orchestrator
-          docker push --all-tags ${{ inputs.remote-repository }}/network-delayer
+        run: DOCKER_PUBLISH_DEV_TAG=true sbt node/Docker/publish strata-indexer/Docker/publish

--- a/.github/workflows/_docker_publish_release.yml
+++ b/.github/workflows/_docker_publish_release.yml
@@ -30,4 +30,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push images to registries
-        run: DOCKER_PUBLISH_LATEST_TAG=true sbt node/Docker/publish genus/Docker/publish
+        run: DOCKER_PUBLISH_LATEST_TAG=true sbt node/Docker/publish strata-indexer/Docker/publish

--- a/.github/workflows/_docker_publish_release.yml
+++ b/.github/workflows/_docker_publish_release.yml
@@ -30,4 +30,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push images to registries
-        run: DOCKER_PUBLISH_LATEST_TAG=true sbt node/Docker/publish strata-indexer/Docker/publish
+        run: DOCKER_PUBLISH_LATEST_TAG=true sbt node/Docker/publish genus/Docker/publish

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - "main"
 
-permissions:
-  checks: write
-  pull-requests: write
-
 jobs:
   sbt-build:
     uses: ./.github/workflows/_sbt_build.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,10 @@ on:
       - "dev"
       - "release-**"
 
+permissions:
+  checks: write
+  pull-requests: write
+
 jobs:
   sbt-build:
     uses: ./.github/workflows/_sbt_build.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - "main"
-      - "dev"
-      - "release-**"
 
 permissions:
   checks: write

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,7 @@
 name: Push
 
 on:
-  pull_request:
+  push:
     branches:
       - "main"
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   checks: write
   pull-requests: write
+  contents: read
+  packages: write
+  id-token: write
 
 jobs:
   sbt-build:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,10 @@ on:
       - "dev"
       - "release-**"
 
+permissions:
+  checks: write
+  pull-requests: write
+
 jobs:
   sbt-build:
     uses: ./.github/workflows/_sbt_build.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,6 +32,4 @@ jobs:
   publish-docker-images-unofficial:
     uses: ./.github/workflows/_docker_publish_dev.yml
     needs: [sbt-build, build-jar]
-    with:
-      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
     secrets: inherit

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,13 +5,6 @@ on:
     branches:
       - "main"
 
-permissions:
-  checks: write
-  pull-requests: write
-  contents: read
-  packages: write
-  id-token: write
-
 jobs:
   sbt-build:
     uses: ./.github/workflows/_sbt_build.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,7 @@
 name: Push
 
 on:
-  push:
+  pull_request:
     branches:
       - "main"
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "dev"
-      - "release-**"
 
 permissions:
   checks: write

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @stratalab/repo-maintainers
+*       @StrataLab/repo-maintainers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,12 +5,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @Topl/bifrost_reviewers
-
-# Order is important. The last matching pattern has the most precedence.
-# So if a pull request only touches javascript files, only these owners
-# will be requested to review.
-#*.js    @octocat @github/js
-
-# You can also use email addresses if you prefer.
-#docs/*  docs@example.com
+*       @stratalab/repo-maintainers

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ lazy val nodeDockerSettings =
       if (sys.env.get("DOCKER_PUBLISH_DEV_TAG").fold(false)(_.toBoolean))
         Seq(
           DockerAlias(Some("docker.io"), Some("stratalab"), "strata-node", Some("dev")),
-          DockerAlias(Some("ghcr.io"), Some("strata"), "strata-node", Some("dev"))
+          DockerAlias(Some("ghcr.io"), Some("stratalab"), "strata-node", Some("dev"))
         )
       else Seq()
       )
@@ -95,7 +95,7 @@ lazy val genusDockerSettings =
       if (sys.env.get("DOCKER_PUBLISH_DEV_TAG").fold(false)(_.toBoolean))
         Seq(
           DockerAlias(Some("docker.io"), Some("stratalab"), "strata-indexer", Some("dev")),
-          DockerAlias(Some("ghcr.io"), Some("strata"), "strata-indexer", Some("dev"))
+          DockerAlias(Some("ghcr.io"), Some("stratalab"), "strata-indexer", Some("dev"))
         )
       else Seq()
       )

--- a/build.sbt
+++ b/build.sbt
@@ -55,12 +55,12 @@ lazy val dockerSettings = Seq(
   dockerBaseImage := "eclipse-temurin:11-jre",
   dockerUpdateLatest := sys.env.get("DOCKER_PUBLISH_LATEST_TAG").fold(false)(_.toBoolean),
   dockerLabels ++= Map(
-    "bifrost.version" -> version.value
+    "strata-node.version" -> version.value
   ),
   dockerAliases := dockerAliases.value.flatMap { alias =>
     Seq(
-      alias.withRegistryHost(Some("docker.io/toplprotocol")),
-      alias.withRegistryHost(Some("ghcr.io/topl"))
+      alias.withRegistryHost(Some("docker.io/stratalab")),
+      alias.withRegistryHost(Some("ghcr.io/stratalab"))
     )
   }
 )
@@ -68,9 +68,9 @@ lazy val dockerSettings = Seq(
 lazy val nodeDockerSettings =
   dockerSettings ++ Seq(
     dockerExposedPorts := Seq(9084, 9085),
-    Docker / packageName := "bifrost-node",
-    dockerExposedVolumes += "/bifrost",
-    dockerExposedVolumes += "/bifrost-staking",
+    Docker / packageName := "strata-node",
+    dockerExposedVolumes += "/strata-node",
+    dockerExposedVolumes += "/strata-node-staking",
     dockerEnvVars ++= Map(
       "BIFROST_APPLICATION_DATA_DIR"    -> "/bifrost/data/{genesisBlockId}",
       "BIFROST_APPLICATION_STAKING_DIR" -> "/bifrost-staking/{genesisBlockId}",
@@ -79,8 +79,8 @@ lazy val nodeDockerSettings =
     dockerAliases ++= (
       if (sys.env.get("DOCKER_PUBLISH_DEV_TAG").fold(false)(_.toBoolean))
         Seq(
-          DockerAlias(Some("docker.io"), Some("toplprotocol"), "bifrost-node", Some("dev")),
-          DockerAlias(Some("ghcr.io"), Some("topl"), "bifrost-node", Some("dev"))
+          DockerAlias(Some("docker.io"), Some("stratalab"), "strata-node", Some("dev")),
+          DockerAlias(Some("ghcr.io"), Some("strata"), "strata-node", Some("dev"))
         )
       else Seq()
       )
@@ -89,13 +89,13 @@ lazy val nodeDockerSettings =
 lazy val genusDockerSettings =
   dockerSettings ++ Seq(
     dockerExposedPorts := Seq(9084),
-    Docker / packageName := "genus",
-    dockerExposedVolumes += "/genus",
+    Docker / packageName := "strata-indexer",
+    dockerExposedVolumes += "/indexer",
     dockerAliases ++= (
       if (sys.env.get("DOCKER_PUBLISH_DEV_TAG").fold(false)(_.toBoolean))
         Seq(
-          DockerAlias(Some("docker.io"), Some("toplprotocol"), "genus", Some("dev")),
-          DockerAlias(Some("ghcr.io"), Some("topl"), "genus", Some("dev"))
+          DockerAlias(Some("docker.io"), Some("stratalab"), "strata-indexer", Some("dev")),
+          DockerAlias(Some("ghcr.io"), Some("strata"), "strata-indexer", Some("dev"))
         )
       else Seq()
       )

--- a/build.sbt
+++ b/build.sbt
@@ -69,8 +69,8 @@ lazy val nodeDockerSettings =
   dockerSettings ++ Seq(
     dockerExposedPorts := Seq(9084, 9085),
     Docker / packageName := "strata-node",
-    dockerExposedVolumes += "/strata-node",
-    dockerExposedVolumes += "/strata-node-staking",
+    dockerExposedVolumes += "/bifrost",
+    dockerExposedVolumes += "/bifrost-staking",
     dockerEnvVars ++= Map(
       "BIFROST_APPLICATION_DATA_DIR"    -> "/bifrost/data/{genesisBlockId}",
       "BIFROST_APPLICATION_STAKING_DIR" -> "/bifrost-staking/{genesisBlockId}",

--- a/byzantine-it/src/test/scala/co/topl/byzantine/util/DockerSupport.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/util/DockerSupport.scala
@@ -125,7 +125,7 @@ object DockerSupport {
       environment: Map[String, String],
       config:      TestNodeConfig
     ): ContainerConfig = {
-      val bifrostImage: String = s"toplprotocol/bifrost-node:${BuildInfo.version}"
+      val bifrostImage: String = s"stratalab/strata-node:${BuildInfo.version}"
       val exposedPorts: Seq[String] = List(config.rpcPort, config.p2pPort, config.jmxRemotePort).map(_.toString)
       val env =
         environment.toList.map { case (key, value) => s"$key=$value" }

--- a/node/example/docker-compose.yaml
+++ b/node/example/docker-compose.yaml
@@ -4,26 +4,26 @@ version: "3.7"
 
 services:
   node1:
-    image: toplprotocol/bifrost-node
+    image: stratalab/strata-node
     command: --config /mnt/special-config.conf --testnetStakerIndex 0
     volumes:
       - ./special-config.conf:/mnt/special-config.conf
   node2:
-    image: toplprotocol/bifrost-node
+    image: stratalab/strata-node
     command: --config /mnt/special-config.conf --testnetStakerIndex 1
     volumes:
       - ./special-config.conf:/mnt/special-config.conf
     environment:
       - BIFROST_P2P_KNOWN_PEERS=node1:9085
   node3:
-    image: toplprotocol/bifrost-node
+    image: stratalab/strata-node
     command: --config /mnt/special-config.conf --testnetStakerIndex 2
     volumes:
       - ./special-config.conf:/mnt/special-config.conf
     environment:
       - BIFROST_P2P_KNOWN_PEERS=node1:9085
   node4:
-    image: toplprotocol/bifrost-node
+    image: stratalab/strata-node
     command: --config /mnt/special-config.conf --testnetStakerIndex 3
     volumes:
       - ./special-config.conf:/mnt/special-config.conf


### PR DESCRIPTION
## Purpose
Update Docker images to publish to new https://hub.docker.com/repositories/stratalab location.

`toplprotocol/bifrost-node` -> `stratalab/strata-node`
`ghcr.io/topl/bifrost-node` -> `ghcr.io/stratalab/strata-node`

`toplprotocol/genus` -> `stratalab/strata-indexer`
`ghcr.io/topl/genus` -> `ghcr.io/stratalab/strata-indexer`

Also update misc CI/CD to get passing build/remove old publish registries.

## Approach
* Update Docker image for `bifrost-node` -> `strata-node`
* Update Docker image for `genus` -> `strata-indexer`
* Remove references to unused GCP Artifact Registry
* Remove `dev` and `release-*` branch triggers. (Just trigger off main/PRs -> main)
* Update CODEOWNERS to use @StrataLab/repo-maintainers 
* Update `docker-compose.yml` example
* Update Byzantine tests to use new Docker image names.

## Testing
* PR Succeeded
* Push succeeded: https://github.com/StrataLab/strata-node/actions/runs/10853596533
* Confirmed new Docker images exist in Dockerhub: https://hub.docker.com/repositories/stratalab
* Confirmed new Docker images exist in ghcr.io: https://github.com/orgs/StrataLab/packages?repo_name=strata-node

## Tickets
*BN-1571

